### PR TITLE
feature/add-crud-functionality-for-markers

### DIFF
--- a/src/main/java/com/street_art_explorer/resource_server/controller/MarkerController.java
+++ b/src/main/java/com/street_art_explorer/resource_server/controller/MarkerController.java
@@ -78,6 +78,15 @@ public class MarkerController {
         return ResponseEntity.noContent().build();
     }
 
+    @PutMapping("/{id}/cover/{photoId}")
+    public ResponseEntity<Void> setCover(@AuthenticationPrincipal Jwt jwt,
+                                         @PathVariable Integer id,
+                                         @PathVariable Integer photoId) {
+        Integer userAuthId = jwtAuthService.requireAuthId(jwt);
+        markerService.setCover(userAuthId, id, photoId);
+        return ResponseEntity.noContent().build();
+    }
+
     @PostMapping("/{id}/photos")
     public ResponseEntity<MarkerPhotoDto> addPhoto(@AuthenticationPrincipal Jwt jwt,
                                                    @PathVariable Integer id,

--- a/src/main/java/com/street_art_explorer/resource_server/controller/UserAppController.java
+++ b/src/main/java/com/street_art_explorer/resource_server/controller/UserAppController.java
@@ -1,13 +1,14 @@
 package com.street_art_explorer.resource_server.controller;
 
+import com.street_art_explorer.resource_server.dto.MarkerDto;
 import com.street_art_explorer.resource_server.dto.PublicUserDto;
+import com.street_art_explorer.resource_server.service.MarkerService;
 import com.street_art_explorer.resource_server.service.UserAppService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/users")
@@ -15,6 +16,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class UserAppController {
 
     private final UserAppService userAppService;
+    private final MarkerService markerService;
 
     @GetMapping("/{id}")
     public ResponseEntity<PublicUserDto> getPublicUserApp(@PathVariable Integer id) {
@@ -24,5 +26,12 @@ public class UserAppController {
 
         PublicUserDto publicUserDto = userAppService.getPublicUserById(id);
         return ResponseEntity.ok(publicUserDto);
+    }
+
+    @GetMapping("/{id}/markers")
+    public ResponseEntity<List<MarkerDto>> getUserMarkers(@PathVariable Integer id,
+                                                          @RequestParam(defaultValue = "100") Integer limit) {
+        List<MarkerDto> list = markerService.getUserMarkersBrief(id, limit);
+        return ResponseEntity.ok(list);
     }
 }

--- a/src/main/java/com/street_art_explorer/resource_server/converter/MarkerConverter.java
+++ b/src/main/java/com/street_art_explorer/resource_server/converter/MarkerConverter.java
@@ -1,17 +1,17 @@
 package com.street_art_explorer.resource_server.converter;
 
+import com.street_art_explorer.resource_server.dto.MarkerDto;
+import com.street_art_explorer.resource_server.dto.MarkerPhotoDto;
+import com.street_art_explorer.resource_server.dto.OwnerDto;
+import com.street_art_explorer.resource_server.dto.PublicUserDto;
+import com.street_art_explorer.resource_server.entity.Marker;
+import com.street_art_explorer.resource_server.entity.MarkerPhoto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
-
-import org.springframework.stereotype.Component;
-
-import com.street_art_explorer.resource_server.dto.MarkerDto;
-import com.street_art_explorer.resource_server.dto.MarkerPhotoDto;
-import com.street_art_explorer.resource_server.entity.Marker;
-import com.street_art_explorer.resource_server.entity.MarkerPhoto;
-
-import lombok.RequiredArgsConstructor;
 
 @Component
 @RequiredArgsConstructor
@@ -41,6 +41,61 @@ public class MarkerConverter {
                 .createdAt(marker.getCreatedAt())
                 .updatedAt(marker.getUpdatedAt())
                 .photos(photoDtos)
+                .build();
+    }
+
+    public MarkerDto markerToMarkerDto(Marker marker, List<MarkerPhoto> photos, PublicUserDto owner) {
+        OwnerDto ownerDto = null;
+        if (owner != null) {
+            ownerDto = OwnerDto.builder()
+                    .id(owner.getId())
+                    .username(owner.getUsername())
+                    .avatarUrl(owner.getAvatarUrl())
+                    .build();
+        }
+
+        String coverUrl = null;
+        if (marker.getCoverPhotoId() != null && photos != null) {
+            coverUrl = photos.stream()
+                    .filter(p -> Objects.equals(p.getId(), marker.getCoverPhotoId()))
+                    .map(MarkerPhoto::getUrl)
+                    .findFirst().orElse(null);
+        }
+
+        List<MarkerPhotoDto> photoDtos = (photos == null ? Collections.<MarkerPhoto>emptyList() : photos)
+                .stream()
+                .filter(Objects::nonNull)
+                .map(markerPhotoConverter::markerPhotoToMarkerPhotoDto)
+                .toList();
+
+        return MarkerDto.builder()
+                .id(marker.getId())
+                .authServerUserId(marker.getAuthServerUserId())
+                .title(marker.getTitle())
+                .description(marker.getDescription())
+                .lat(marker.getLat())
+                .lng(marker.getLng())
+                .address(marker.getAddress())
+                .avgRating(marker.getAvgRating())
+                .ratingsCount(marker.getRatingsCount())
+                .photos(photoDtos)
+                .owner(ownerDto)
+                .coverPhotoId(marker.getCoverPhotoId())
+                .coverPhotoUrl(coverUrl)
+                .build();
+    }
+
+    public MarkerDto markerToMarkerDtoBrief(Marker marker) {
+        return MarkerDto.builder()
+                .id(marker.getId())
+                .authServerUserId(marker.getAuthServerUserId())
+                .title(marker.getTitle())
+                .description(marker.getDescription())
+                .lat(marker.getLat())
+                .lng(marker.getLng())
+                .address(marker.getAddress())
+                .avgRating(marker.getAvgRating())
+                .ratingsCount(marker.getRatingsCount())
                 .build();
     }
 

--- a/src/main/java/com/street_art_explorer/resource_server/converter/UserAppConverter.java
+++ b/src/main/java/com/street_art_explorer/resource_server/converter/UserAppConverter.java
@@ -14,6 +14,7 @@ public class UserAppConverter {
         if (userApp == null) return null;
 
         return UserAppDto.builder()
+                .id(userApp.getId())
                 .authServerUserId(userApp.getAuthServerUserId())
                 .username(userApp.getUsername())
                 .email(userApp.getEmail())
@@ -32,6 +33,7 @@ public class UserAppConverter {
         if (userAppDto == null) return null;
 
         return UserApp.builder()
+                .id(userAppDto.getId())
                 .authServerUserId(userAppDto.getAuthServerUserId())
                 .username(userAppDto.getUsername())
                 .email(userAppDto.getEmail())
@@ -56,6 +58,7 @@ public class UserAppConverter {
                 .lastName(userApp.getLastName())
                 .birthDate(userApp.getBirthDate())
                 .bio(userApp.getBio())
+                .createdAt(userApp.getCreatedAt())
                 .avatarUrl(userApp.getAvatarUrl())
                 .avatarPublicId(userApp.getAvatarPublicId())
                 .build();

--- a/src/main/java/com/street_art_explorer/resource_server/dto/MarkerDto.java
+++ b/src/main/java/com/street_art_explorer/resource_server/dto/MarkerDto.java
@@ -1,13 +1,13 @@
 package com.street_art_explorer.resource_server.dto;
 
-import java.math.BigDecimal;
-import java.time.LocalDateTime;
-import java.util.List;
-
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
 
 @NoArgsConstructor
 @AllArgsConstructor
@@ -27,4 +27,8 @@ public class MarkerDto {
     private LocalDateTime updatedAt;
     private List<MarkerPhotoDto> photos;
     private Boolean ownedByMe;
+
+    private OwnerDto owner;
+    private Integer coverPhotoId;
+    private String coverPhotoUrl;
 }

--- a/src/main/java/com/street_art_explorer/resource_server/dto/OwnerDto.java
+++ b/src/main/java/com/street_art_explorer/resource_server/dto/OwnerDto.java
@@ -5,22 +5,12 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDateTime;
-import java.util.Date;
-
 @NoArgsConstructor
 @AllArgsConstructor
 @Data
 @Builder
-public class PublicUserDto {
-
+public class OwnerDto {
     private Integer id;
     private String username;
-    private String firstName;
-    private String lastName;
-    private Date birthDate;
-    private String bio;
-    private LocalDateTime createdAt;
     private String avatarUrl;
-    private String avatarPublicId;
 }

--- a/src/main/java/com/street_art_explorer/resource_server/dto/UserAppDto.java
+++ b/src/main/java/com/street_art_explorer/resource_server/dto/UserAppDto.java
@@ -13,7 +13,7 @@ import java.util.Date;
 @Data
 @Builder
 public class UserAppDto {
-
+    private Integer id;
     private Integer authServerUserId;
     private String username;
     private String email;

--- a/src/main/java/com/street_art_explorer/resource_server/entity/Marker.java
+++ b/src/main/java/com/street_art_explorer/resource_server/entity/Marker.java
@@ -1,20 +1,13 @@
 package com.street_art_explorer.resource_server.entity;
 
-import java.math.BigDecimal;
-import java.time.LocalDateTime;
-
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.PrePersist;
-import jakarta.persistence.PreUpdate;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
 
 @Entity
 @Table(name = "markers")
@@ -53,6 +46,9 @@ public class Marker {
 
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
+
+    @Column(name = "cover_photo_id")
+    private Integer coverPhotoId;
 
     @PrePersist
     void prePersist() {

--- a/src/main/java/com/street_art_explorer/resource_server/repository/MarkerPhotoRepository.java
+++ b/src/main/java/com/street_art_explorer/resource_server/repository/MarkerPhotoRepository.java
@@ -4,6 +4,7 @@ import com.street_art_explorer.resource_server.entity.MarkerPhoto;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
@@ -12,4 +13,6 @@ public interface MarkerPhotoRepository extends JpaRepository<MarkerPhoto, Intege
     List<MarkerPhoto> findByMarkerIdOrderByIdAsc(Integer markerId);
 
     Optional<MarkerPhoto> findByIdAndMarkerId(Integer photoId, Integer markerId);
+
+    List<MarkerPhoto> findByMarkerIdInOrderByMarkerIdAscPositionAscIdAsc(Collection<Integer> markerIds);
 }

--- a/src/main/java/com/street_art_explorer/resource_server/repository/MarkerRepository.java
+++ b/src/main/java/com/street_art_explorer/resource_server/repository/MarkerRepository.java
@@ -38,4 +38,6 @@ public interface MarkerRepository extends JpaRepository<Marker, Integer> {
     List<Marker> findNearMarkers(@Param("lat0") double lat0,
                                  @Param("lng0") double lng0,
                                  @Param("limit") int limit);
+
+    List<Marker> findByAuthServerUserIdOrderByCreatedAtDesc(Integer authServerUserId);
 }

--- a/src/main/java/com/street_art_explorer/resource_server/repository/UserAppRepository.java
+++ b/src/main/java/com/street_art_explorer/resource_server/repository/UserAppRepository.java
@@ -4,9 +4,13 @@ import com.street_art_explorer.resource_server.entity.UserApp;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Collection;
+import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface UserAppRepository extends JpaRepository<UserApp, Integer> {
     Optional<UserApp> findByAuthServerUserId(Integer authServerUserId);
+
+    List<UserApp> findByAuthServerUserIdIn(Collection<Integer> authIds);
 }

--- a/src/main/java/com/street_art_explorer/resource_server/service/MarkerService.java
+++ b/src/main/java/com/street_art_explorer/resource_server/service/MarkerService.java
@@ -20,5 +20,9 @@ public interface MarkerService {
 
     List<MarkerDto> getNearMarkers(double lat, double lng, int limit);
 
+    List<MarkerDto> getUserMarkersBrief(Integer userId, int limit);
+
     void deleteMarker(Integer authId, Integer markerId);
+
+    void setCover(Integer authId, Integer markerId, Integer photoId);
 }

--- a/src/main/java/com/street_art_explorer/resource_server/service/implementation/MarkerServiceImpl.java
+++ b/src/main/java/com/street_art_explorer/resource_server/service/implementation/MarkerServiceImpl.java
@@ -1,27 +1,26 @@
 package com.street_art_explorer.resource_server.service.implementation;
 
-import java.util.List;
-import java.util.Objects;
-
+import com.street_art_explorer.resource_server.converter.MarkerConverter;
+import com.street_art_explorer.resource_server.converter.UserAppConverter;
+import com.street_art_explorer.resource_server.dto.*;
+import com.street_art_explorer.resource_server.entity.Marker;
+import com.street_art_explorer.resource_server.entity.MarkerPhoto;
+import com.street_art_explorer.resource_server.entity.UserApp;
+import com.street_art_explorer.resource_server.repository.MarkerPhotoRepository;
+import com.street_art_explorer.resource_server.repository.MarkerRatingRepository;
+import com.street_art_explorer.resource_server.repository.MarkerRepository;
+import com.street_art_explorer.resource_server.repository.UserAppRepository;
+import com.street_art_explorer.resource_server.service.JwtAuthService;
+import com.street_art_explorer.resource_server.service.MarkerService;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.server.ResponseStatusException;
 
-import com.street_art_explorer.resource_server.converter.MarkerConverter;
-import com.street_art_explorer.resource_server.dto.CreateMarkerRequest;
-import com.street_art_explorer.resource_server.dto.MarkerDto;
-import com.street_art_explorer.resource_server.dto.UpdateMarkerRequest;
-import com.street_art_explorer.resource_server.entity.Marker;
-import com.street_art_explorer.resource_server.entity.MarkerPhoto;
-import com.street_art_explorer.resource_server.repository.MarkerPhotoRepository;
-import com.street_art_explorer.resource_server.repository.MarkerRatingRepository;
-import com.street_art_explorer.resource_server.repository.MarkerRepository;
-import com.street_art_explorer.resource_server.service.JwtAuthService;
-import com.street_art_explorer.resource_server.service.MarkerService;
-
-import jakarta.persistence.EntityNotFoundException;
-import lombok.RequiredArgsConstructor;
+import java.util.*;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -34,6 +33,8 @@ public class MarkerServiceImpl implements MarkerService {
     private final JwtAuthService jwtAuthService;
 
     private final MarkerConverter markerConverter;
+    private final UserAppRepository userAppRepository;
+    private final UserAppConverter userAppConverter;
 
     @Transactional
     public Marker requireOwned(Integer markerId, Integer authorId) {
@@ -105,22 +106,21 @@ public class MarkerServiceImpl implements MarkerService {
 
         Integer currentAuthId = jwtAuthService.getOptionalAuthId().orElse(null);
 
-        MarkerDto markerDto = markerConverter.markerToMarkerDto(marker, photos);
+        UserApp owner = userAppRepository.findByAuthServerUserId(marker.getAuthServerUserId()).orElse(null);
+        PublicUserDto ownerDto = owner == null ? null : userAppConverter.userAppToPublicUserDto(owner);
+
+        MarkerDto markerDto = markerConverter.markerToMarkerDto(marker, photos, ownerDto);
         markerDto.setOwnedByMe(Objects.equals(markerDto.getAuthServerUserId(), currentAuthId));
         return markerDto;
     }
 
     @Override
     @Transactional(readOnly = true)
-    public List<MarkerDto> getBBoxMarkers(double minLat, double maxLat, double minLng, double maxLng, int limit) {
-        int lim = Math.max(1, Math.min(limit, 500));
+    public List<MarkerDto> getBBoxMarkers(
+            double minLat, double maxLat, double minLng, double maxLng, int limit) {
+        int lim = Math.max(1, Math.min(limit, 200));
         List<Marker> markers = markerRepository.findBBoxMarkers(minLat, maxLat, minLng, maxLng, lim);
-
-        Integer currentAuthId = jwtAuthService.getOptionalAuthId().orElse(null);
-
-        List<MarkerDto> markerDtos = markerConverter.markersToMarkerDtos(markers);
-        markerDtos.forEach(dto -> dto.setOwnedByMe(Objects.equals(dto.getAuthServerUserId(), currentAuthId)));
-        return markerDtos;
+        return assembleBriefDtos(markers);
     }
 
     @Override
@@ -132,10 +132,107 @@ public class MarkerServiceImpl implements MarkerService {
     }
 
     @Override
+    @Transactional(readOnly = true)
+    public List<MarkerDto> getUserMarkersBrief(Integer userId, int limit) {
+        int lim = Math.max(1, Math.min(limit, 200));
+
+        UserApp user = userAppRepository.findById(userId)
+                .orElseThrow(() -> new NoSuchElementException("User not found"));
+
+        List<Marker> all = markerRepository.findByAuthServerUserIdOrderByCreatedAtDesc(user.getAuthServerUserId());
+        List<Marker> slice = all.size() > lim ? all.subList(0, lim) : all;
+        return assembleBriefDtos(slice);
+    }
+
+    @Override
     @Transactional
     public void deleteMarker(Integer authId, Integer markerId) {
         Marker marker = requireOwned(markerId, authId);
         markerRepository.deleteById(marker.getId());
     }
 
+    @Override
+    @Transactional
+    public void setCover(Integer authId, Integer markerId, Integer photoId) {
+        Marker marker = requireOwned(markerId, authId);
+        MarkerPhoto photo = markerPhotoRepository.findByIdAndMarkerId(photoId, markerId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Photo not found"));
+        marker.setCoverPhotoId(photo.getId());
+        markerRepository.save(marker);
+    }
+
+    private List<MarkerDto> assembleBriefDtos(List<Marker> markers) {
+        if (markers == null || markers.isEmpty()) return List.of();
+
+        Integer currentAuthId = jwtAuthService.getOptionalAuthId().orElse(null);
+
+        Set<Integer> authIds = markers.stream()
+                .map(Marker::getAuthServerUserId)
+                .filter(Objects::nonNull)
+                .collect(Collectors.toSet());
+
+        var userApps = userAppRepository.findByAuthServerUserIdIn(authIds);
+
+        Map<Integer, PublicUserDto> ownersByAuthId = new HashMap<>();
+        for (var ua : userApps) {
+            ownersByAuthId.put(ua.getAuthServerUserId(), userAppConverter.userAppToPublicUserDto(ua));
+        }
+
+        Set<Integer> markerIds = markers.stream().map(Marker::getId).collect(Collectors.toSet());
+        List<MarkerPhoto> photos = markerPhotoRepository
+                .findByMarkerIdInOrderByMarkerIdAscPositionAscIdAsc(markerIds);
+
+        Map<Integer, List<MarkerPhoto>> photosByMarkerId = new HashMap<>();
+        for (MarkerPhoto p : photos) {
+            photosByMarkerId.computeIfAbsent(p.getMarker().getId(), k -> new ArrayList<>()).add(p);
+        }
+
+        Map<Integer, MarkerPhoto> coverByMarkerId = new HashMap<>();
+        for (Marker m : markers) {
+            List<MarkerPhoto> list = photosByMarkerId.getOrDefault(m.getId(), List.of());
+            if (list.isEmpty()) continue;
+
+            MarkerPhoto cover = null;
+            Integer coverId = m.getCoverPhotoId();
+            if (coverId != null) {
+                cover = list.stream().filter(p -> coverId.equals(p.getId())).findFirst().orElse(null);
+            }
+            if (cover == null) cover = list.get(0);
+            coverByMarkerId.put(m.getId(), cover);
+        }
+
+        List<MarkerDto> result = new ArrayList<>(markers.size());
+        for (Marker m : markers) {
+            PublicUserDto ownerPublic = ownersByAuthId.get(m.getAuthServerUserId());
+
+            OwnerDto ownerDto = null;
+            if (ownerPublic != null) {
+                ownerDto = OwnerDto.builder()
+                        .id(ownerPublic.getId())
+                        .username(ownerPublic.getUsername())
+                        .avatarUrl(ownerPublic.getAvatarUrl())
+                        .build();
+            }
+
+            MarkerPhoto cover = coverByMarkerId.get(m.getId());
+            String coverUrl = null;
+            Integer coverId = null;
+            if (cover != null) {
+                coverId = cover.getId();
+                coverUrl = cover.getThumbnailUrl() != null ? cover.getThumbnailUrl()
+                        : cover.getSecureUrl() != null ? cover.getSecureUrl()
+                        : cover.getUrl();
+            }
+
+            MarkerDto dto = markerConverter.markerToMarkerDtoBrief(m);
+            dto.setOwner(ownerDto);
+            dto.setCoverPhotoId(coverId);
+            dto.setCoverPhotoUrl(coverUrl);
+            dto.setOwnedByMe(Objects.equals(m.getAuthServerUserId(), currentAuthId));
+            dto.setPhotos(null);
+
+            result.add(dto);
+        }
+        return result;
+    }
 }

--- a/src/main/resources/db/migration/V7__add_cover_photo_field_to_marker.sql
+++ b/src/main/resources/db/migration/V7__add_cover_photo_field_to_marker.sql
@@ -1,0 +1,1 @@
+ALTER TABLE markers ADD COLUMN cover_photo_id INT NULL;


### PR DESCRIPTION
An endpoint to set a cover for a marker was added with its respective service method. 
Marker table, entity and dtos were adapted to add this new field and it was cosidered in the marker converter as well. 
An endpoint to get all markers posted or owned by an user was added with its respective service method. 
User dtos were modified to return a new field that wasn't considered before.